### PR TITLE
Add enviroment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
     - [Local Development](#local-development)
     - [Linting](#linting)
     - [Build and serve](#build-and-serve)
+  - [Deployment](#deployment)
+    - [GitHub Pages](#github-pages)
+    - [Docker Image](#docker-image)
   - [Contributing](#contributing)
 
 This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
@@ -24,6 +27,7 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 10. Each page is built using the [template](/template.mdx) (validated by `npm run lint:mdx`).
 11. Custom components should not implement their own title, they should use the correct heading (#) level in the page itself to ensure proper url based linking.
 12. Images need to have padding applied around them, optimally `2rem`.
+13. Code has no 'TODO' blocks, only a 'FUTURE_WORK' block may be present with a reference to an issue or task.
 
 ## Installation
 
@@ -64,6 +68,25 @@ And then to serve the newly created build, simply run.
 ```bash
  npm run serve
 ```
+
+## Deployment
+
+To deploy the website, there are multiple options available depending on your hosting preferences. But first you should create a `.env` file in the root directory of the project with the following content:
+
+```env
+# This value MUST start and end with a slash '/', unless it's the root '/'.
+BASE_URL=''
+```
+
+This step is only necessary when you want to differ from the default `baseUrl` value of `/`. This is particularly useful when deploying to GitHub Pages under a repository, e.g., `https://username.github.io/repository-name/`, where the `BASE_URL` should be set to `/repository-name/`. See the [Docusaurus docs](https://docusaurus.io/docs/api/docusaurus-config#baseUrl) for more information
+
+### GitHub Pages
+
+T.B.A
+
+### Docker Image
+
+T.B.A
 
 ## Contributing
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,8 +2,10 @@ import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import packageJson from "./package.json";
+import "dotenv/config";
 
-//todo enable search
+const baseUrlOrDefault = process.env.BASE_URL || "/";
+
 const config: Config = {
   title: "Design Pattern Pedia",
   tagline: "Practicing Patterns Made Plain and Practical",
@@ -12,7 +14,11 @@ const config: Config = {
     v4: true,
   },
   url: "https://your-docusaurus-site.example.com",
-  baseUrl: "/",
+  baseUrl: baseUrlOrDefault,
+  customFields: {
+    // We need to pass this directly as process.env is not available in the client bundle. But we do need this variable in the client bundle.
+    baseUrl: baseUrlOrDefault,
+  },
   organizationName: "S7-OpenLearning-Individual",
   projectName: "DesignPatternPedia",
   onBrokenLinks: "throw",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "design-pattern-pedia",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "design-pattern-pedia",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",
@@ -15,6 +15,7 @@
         "@easyops-cn/docusaurus-search-local": "^0.52.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "dotenv": "^17.2.3",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -9181,6 +9182,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.52.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "dotenv": "^17.2.3",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/navigator/PatternResult.tsx
+++ b/src/components/navigator/PatternResult.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styles from "./navigator.module.css";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 const baseURL = "/DesignPatternPedia/docs";
 
@@ -16,6 +17,12 @@ const PatternResult: React.FC<PatternResultProps> = ({
   path,
   onReset,
 }) => {
+  const {
+    siteConfig: { customFields },
+  } = useDocusaurusContext();
+
+  const baseUrlOrDefault = customFields.baseUrl || "/";
+
   return (
     <>
       <div className={styles.divider} />
@@ -23,7 +30,10 @@ const PatternResult: React.FC<PatternResultProps> = ({
         <h2>{name}</h2>
         <p>{description}</p>
         <div className={styles.resultButtons}>
-          <a href={`${baseURL}/${path}`} className="button button--primary">
+          <a
+            href={`${baseUrlOrDefault}docs/${path}`}
+            className="button button--primary"
+          >
             Learn More
           </a>
           <button


### PR DESCRIPTION
[Related issue #33](https://github.com/S7-OpenLearning-Individual/DesignPatternPedia/issues/33)

This PR proposes to do the following;
- Add .env variable support, with a default fallback to `/`.
- Remove old 'TODO' comment from config file.
- Add docs regarding config files.
- Update code standards regarding TODOs and FUTURE_WORKs.
- Add `dotenv` package.
- Fix navigator not using correct base URL.
- Add initial version of deployment docs.